### PR TITLE
Remove fname in dla

### DIFF
--- a/bin/dla_saclay.py
+++ b/bin/dla_saclay.py
@@ -184,7 +184,7 @@ def add_DLA_table_to_object_Saclay(hdulist,dNdz_arr,dz_of_z,dla_bias=2.0,extrapo
     # y = interp1d(z_cell,D_cell)
     # bias = dla_bias/(D_cell)*y(2.25)  # (npix)
     # sigma_g = fitsio.FITS(fname_sigma)[0].read_header()['SIGMA']
-    sigma_g = 1.19
+    sigma_g = constant.sigma_g
     # Gaussian field threshold:
     nu_arr = nu_of_bD(dla_bias*sigma_g*D_cell)  # (npix)
     #Figure out cells that could host a DLA, based on Gaussian fluctuation

--- a/bin/dla_saclay.py
+++ b/bin/dla_saclay.py
@@ -161,7 +161,7 @@ def get_N(z, Nmin=20.0, Nmax=22.5, nsamp=100):
     return NHI
 
 
-def add_DLA_table_to_object_Saclay(hdulist,fname_sigma,dNdz_arr,dz_of_z,dla_bias=2.0,extrapolate_z_down=None,Nmin=20.0,Nmax=22.5,zlow=1.8):
+def add_DLA_table_to_object_Saclay(hdulist,dNdz_arr,dz_of_z,dla_bias=2.0,extrapolate_z_down=None,Nmin=20.0,Nmax=22.5,zlow=1.8):
     qso = hdulist['METADATA'].read() # Read the QSO table
     lam = hdulist['LAMBDA'].read() # Read the vector with the wavelenghts corresponding to each cell
     deltas = hdulist['DELTA'].read()  # (nspec, npix)
@@ -246,10 +246,6 @@ parser.add_argument('--output_file', type = str, default = None, required = True
                     help='Output filename')
 parser.add_argument('--input_pattern', type = str, default = 'spectra_merged*.fits',
                     help='Filename pattern')
-# parser.add_argument('--fname_cosmo', type = str, default = None, required = True,
-#                     help='Path to file with cosmological parameter information')
-parser.add_argument('--fname_sigma', type = str, default = None, required = True,
-                    help='Path to file with information sigma(0) (initial density field RMS)')
 parser.add_argument('--nmin', type = float, default=17.2,
                     help='Minimum value of log(NHI) to consider')
 parser.add_argument('--nmax', type = float, default=22.5,
@@ -290,7 +286,7 @@ ndlas = 0
 for i, fname in enumerate(flist):
     try:
         hdulist = fitsio.FITS(fname)
-        aux, n = add_DLA_table_to_object_Saclay(hdulist, args.fname_sigma, dNdz_arr,dz_of_z, args.dla_bias, Nmin=args.nmin, Nmax=args.nmax)
+        aux, n = add_DLA_table_to_object_Saclay(hdulist, dNdz_arr,dz_of_z, args.dla_bias, Nmin=args.nmin, Nmax=args.nmax)
         hdulist.close()
     except IOError:
         print("WARNING: can't read fname")

--- a/bin/submit_mocks.py
+++ b/bin/submit_mocks.py
@@ -326,7 +326,7 @@ def mergechunks(todo, mock_args, sbatch_args):
         for cid in mock_args['chunkid']:
             if mock_args['use_time']:
                 script += """/usr/bin/time -f "%eReal %Uuser %Ssystem %PCPU %M " """
-            script += "dla_saclay.py --input_path {base}/chunk_{i}/spectra_merged/ --output_file {base}/chunk_{i}/dla.fits --fname_sigma {base}/chunk_{i}/boxes/box-0.fits --input_pattern spectra_merged*.fits --cell_size {pixel} --nmin {nmin} --nmax {nmax} {seed} ".format(base=mock_args['base_dir'], i=cid, pixel=mock_args['pixel_size'], nmin=mock_args['nmin'], nmax=mock_args['nmax'], seed=mock_args['seed'])
+            script += "dla_saclay.py --input_path {base}/chunk_{i}/spectra_merged/ --output_file {base}/chunk_{i}/dla.fits --input_pattern spectra_merged*.fits --cell_size {pixel} --nmin {nmin} --nmax {nmax} {seed} ".format(base=mock_args['base_dir'], i=cid, pixel=mock_args['pixel_size'], nmin=mock_args['nmin'], nmax=mock_args['nmax'], seed=mock_args['seed'])
             script += "&> {path}/dla-{i}.log &\n".format(path=mock_args['logs_dir_mergechunks'], i=cid)
             script += """pids+=" $!"\n"""
         script += get_errors("dla_saclay", 0)

--- a/py/SaclayMocks/constant.py
+++ b/py/SaclayMocks/constant.py
@@ -12,15 +12,6 @@ lylimit = lya * 3 /4. # 911.75  ok with https://en.wikipedia.org/wiki/Hydrogen_s
 lyb = lylimit * 9./8. # 1025.72  https://en.wikipedia.org/wiki/Hydrogen_spectral_series : 1025.7
 lambda_min = 3530.  # Lambda min in A (given by Stephen Bailey - 04/05/2018)
 
-# Not used:
-R_H = 10973731.568 # m^-1  https://en.wikipedia.org/wiki/Rydberg_constant
-                # pdg gives hc R_H -> 100000*13.605693009/197.3269788/2/np.pi
-                # i.e. 1097.373156849444
-#lylimit = 1E10/R_H # 911.27 angtroem !!!
-#lya = lylimit * 4 / 3.  #  1215.0227
-#lyb = lylimit * 9 / 8.  # 1025.18
-
-
 # Cosmo params given by Helion in a mail (30/03/2018)
 # should correspond to Planck 2015
 h = 0.6731
@@ -40,34 +31,5 @@ H0 = 100.  # In km/s /(Mpc/h)
 deg2rad = sp.pi/180.
 rad2deg = 180/sp.pi
 
-#boss_lambda_min = 3600.
-
-
-'''
-class cosmo:
-
-    def __init__(self,Om,Ok=0):
-        H0 = 100. ## km/s/Mpc
-        ## ignore Orad and neutrinos
-        nbins=10000
-        zmax=10.
-        dz = zmax/nbins
-        z=sp.array(range(nbins))*dz
-        hubble = H0*sp.sqrt(Om*(1+z)**3+Ok*(1+z)**2+1-Ok-Om)
-
-        chi=sp.zeros(nbins)
-        for i in range(1,nbins):
-            chi[i]=chi[i-1]+c*(1./hubble[i-1]+1/hubble[i])/2.*dz
-
-        self.r_comoving = interpolate.interp1d(z,chi)
-
-        ## da here is the comoving angular diameter distance
-        da = chi
-        if Ok<0:
-            da = sp.sin(H0*sp.sqrt(-Ok)/c*chi)/(H0*sp.sqrt(-Ok)/c)
-        if Ok>0:
-            da = sp.sinh(H0*sp.sqrt(Ok)/c*chi)/(H0*sp.sqrt(Ok)/c)
-        self.da = interpolate.interp1d(z,da)
-        self.hubble = interpolate.interp1d(z,hubble)
-        self.r_2_z = interpolate.interp1d(chi,z)
-'''
+# Hardcoded params:
+sigma_g = 1.19


### PR DESCRIPTION
Removed the argument --fname_sigma in dla_saclay.py: it was useless
sigma_g is currently hardcoded. I moved the set up of its value to constant.py